### PR TITLE
[GLA-548] refactor: remove v1 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Welcome to [Gladia Documentation](https://docs.gladia.io)
 
-> [!NOTE]
-> To access V1 documentation (deprecation April 1st, 2024) click [Here](https://docs-v1.gladia.io) 
 
 ### Installing dependencies
 

--- a/chapters/introduction/pages/introduction.mdx
+++ b/chapters/introduction/pages/introduction.mdx
@@ -44,7 +44,3 @@ in both live and asynchronous ways, with audio intelligence tools to extract, an
 
 
 <br/>
-
-<Note>
-Looking for old V1 documentation? It's still available until April 1st, 2024 [here](https://docs-v1.gladia.io/reference/introduction).
-</Note>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Removed outdated notes regarding the deprecation of V1 documentation from the README and introduction pages, streamlining user access to current resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->