### PR TITLE
fix: remove references to V1 introduction.mdx

### DIFF
--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -5,8 +5,6 @@ description: 'Technical documentation for Gladia API'
 
 <Note>
   If you're not looking for technical API reference documentation, you can check our [Quickstart guide](/chapters/get-started/pages/transcribe-audio).
-
-  Looking for old V1 documentation? It's still available [here](https://docs.gladia.io/reference/introduction). 
 </Note>
 
 **Gladia API** aims to provide a complete set of resources alongside with its **state-of-the-art API** features to makes the integration


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the introduction section of the Gladia API documentation by removing the link to the old V1 documentation.
	- Enhanced clarity on features and structure, emphasizing ease of integration and adherence to REST standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->