### PR TITLE
[GLA-1876] feat: add language_guidance for pre-reocorded

### DIFF
--- a/chapters/live-stt/features.mdx
+++ b/chapters/live-stt/features.mdx
@@ -6,84 +6,11 @@ description: "Core features of Gladia's real-time speech-to-text (STT) API "
 import CustomVocabularyInputDescription from '/snippets/custom-vocabulary-input-description.mdx'
 import CustomSpellingStartDescription from '/snippets/custom-spelling-start-description.mdx'
 import CustomSpellingEndDescription from '/snippets/custom-spelling-end-description.mdx'
+import Languages from '/snippets/languages.mdx'
 
 <Note>All the configuration properties described below are defined in the [POST /v2/live endpoint](/api-reference/v2/live/init).</Note>
 
-## Language configuration
-
-### Single language
-
-If you know the language of the conversation in advance, specify it in the `language_config.languages` parameter to ensure the best transcription results.
-
-```json
-{
-  "language_config": {
-    "languages": ["en"]
-  }
-}
-```
-
-If the spoken language is unknown, you can:
-- Omit the `language_config.languages` parameter; the model will automatically detect the language from the first few seconds of audio **across all supported languages**.
-- Specify multiple languages in the `language_config.languages` parameter; the model will detect the language from the first few seconds of audio **within the provided options**.
-
-<CodeGroup>
-
-```json Limited options
-{
-  // Will limit to detect from English, French or Spanish
-  "language_config": {
-    "languages": ["en", "fr", "es"]
-  }
-}
-```
-
-```json All languages
-{
-  // You can omit the parameter
-  "language_config": {
-    "languages": []
-  }
-}
-```
-
-</CodeGroup>
-
-### Multiple languages <br/>(Code-switching)
-
-If you expect multiple languages to be spoken during the conversation, enable the `language_config.code_switching` parameter. This will allow the model to switch languages dynamically and reflect it in the transcription results.
-
-As with single-language configuration, you can either let the model detect the language from **all supported languages** or specify a **set of options** to narrow down the selection.
-
-<CodeGroup>
-
-```json Limited options
-{
-  "language_config": {
-    // Will limit to detect from English, French or Spanish
-    "languages": ["en", "fr", "es"],
-    "code_switching": true
-  }
-}
-```
-
-```json All languages
-{
-  "language_config": {
-    // You can omit the languages parameter
-    "languages": [],
-    "code_switching": true
-  }
-}
-```
-
-</CodeGroup>
-
-<br/>
-
-<Tip>
-It is recommended to limit the number of languages to avoid incorrect detection, either in single or multiple languages configuration. Some languages, such as those from Eastern European countries, have similar sounds, which may cause the model to confuse them and produce a transcription in the wrong language.
-</Tip>
+<Languages />
 
 ## Word-level timestamps
 

--- a/chapters/pre-recorded-stt/features.mdx
+++ b/chapters/pre-recorded-stt/features.mdx
@@ -6,6 +6,7 @@ description: "Core features of the Gladia Pre-recorded STT API"
 import CustomVocabularyInputDescription from '/snippets/custom-vocabulary-input-description.mdx';
 import CustomSpellingStartDescription from '/snippets/custom-spelling-start-description.mdx';
 import CustomSpellingEndDescription from '/snippets/custom-spelling-end-description.mdx';
+import Languages from '/snippets/languages.mdx'
 
 The core functionality of the Gladia API is its Speech Recognition model, designed to convert spoken language
  into written text. This serves as the basis for all Gladia API offerings.
@@ -18,6 +19,8 @@ Discover our state-of-the-art ASR model [ Whisper Zero now.](https://www.gladia.
 
  Additional capabilities, like Speaker Diarization, Summarization, Translation, Custom Prompts and more can be integrated seamlessly
  into the transcription process by including extra parameters in the transcription request.
+
+<Languages />
 
 
 ## Enhanced punctuation
@@ -119,64 +122,6 @@ The result will contain a `sentences` key (in addition to `utterances`):
       ]
     }
 ```
-
-## Automatic language detection
-
-With automatic language detection, Gladia will identify the dominant language spoken in an audio file and use it during the transcription. This behaviour can be toggled with the `detect_language` parameter.
-
-**Automatic language detection is turned on by default.**
-
-```json request data
-{
-  "audio_url": "YOUR_AUDIO_URL",
-  "detect_language": true
-}
-```
-
-## Multiple languages detection <br/>(Code switching)
-By enabling code switching, the model will continuously detect the spoken language and switch the transcription language accordingly.
-This behaviour is recommended for specific scenarios where the language is changed multiple times throughout the audio (e.g. a conversation between 2 people, each speaking a different language.), 
-
-Please note that certain strong accents may  possibly cause this mode to transcribe to the wrong language.
-
-To enable or disable it, set `enable_code_switching` to true in the request body parameters. (default to `false`)
-
-```json request data
-{
-  "audio_url": "YOUR_AUDIO_URL",
-  "enable_code_switching": true
-}
-```
-
-### Guided code switching
-When code switching is enabled, you may provide a list of languages to the model, ensuring the model will only detect these languages.
-
-```json request data
-{
-  "audio_url": "YOUR_AUDIO_URL",
-  "enable_code_switching": true,
-  "code_switching_config": {
-    "languages": ["en", "es", "fr"]
-  }
-}
-```
-
-
-## Manual transcription language
-If you already know the dominant language, you can disable language detection by setting `detect_language` to `false` and manually set the the language with the `language` key.
-
-<Warning>
-In order to use manual language `detect_language` must be disabled, otherwise the `language` parameter will be ignored.
-</Warning>
-
-```json request data
-{
-  "audio_url": "YOUR_AUDIO_URL",
-  "detect_language": false,
-  "language": "fr"
-}
-```
-
 
 ## Export SRT or VTT caption files
 

--- a/snippets/languages.mdx
+++ b/snippets/languages.mdx
@@ -1,0 +1,85 @@
+## Language configuration
+
+### Single language
+
+If you know the language of the conversation in advance, specify it in the `language_config.languages` parameter to ensure the best transcription results.
+
+```json
+{
+  ...rest of the config
+  "language_config": {
+    "languages": ["en"]
+  }
+}
+```
+
+If the spoken language is unknown, you can:
+
+- Omit the `language_config.languages` parameter; the model will automatically detect the language from the first few seconds of audio **across all supported languages**.
+- Specify multiple languages in the `language_config.languages` parameter; the model will detect the language from the first few seconds of audio **within the provided options**.
+
+<CodeGroup>
+
+```json Limited options
+{
+  ...rest of the config
+  // Will limit to detect from English, French or Spanish
+  "language_config": {
+    "languages": ["en", "fr", "es"]
+  }
+}
+```
+
+```json All languages
+{
+  ...rest of the config
+  // You can omit the parameter
+  "language_config": {
+    "languages": []
+  }
+}
+```
+
+</CodeGroup>
+
+### Multiple languages <br/>(Code-switching)
+
+If you expect multiple languages to be spoken during the conversation, enable the `language_config.code_switching` parameter. This will allow the model to switch languages dynamically and reflect it in the transcription results.
+
+As with single-language configuration, you can either let the model detect the language from **all supported languages** or specify a **set of options** to narrow down the selection.
+
+<CodeGroup>
+
+```json Limited options
+{
+  ...rest of the config
+  "language_config": {
+    // Will limit to detect from English, French or Spanish
+    "languages": ["en", "fr", "es"],
+    "code_switching": true
+  }
+}
+```
+
+```json All languages
+{
+  ...rest of the config
+  "language_config": {
+    // You can omit the languages parameter
+    "languages": [],
+    "code_switching": true
+  }
+}
+```
+
+</CodeGroup>
+
+<br />
+
+<Tip>
+  It is recommended to limit the number of languages to avoid incorrect
+  detection, either in single or multiple languages configuration. Some
+  languages, such as those from Eastern European countries, have similar sounds,
+  which may cause the model to confuse them and produce a transcription in the
+  wrong language.
+</Tip>

--- a/snippets/languages.mdx
+++ b/snippets/languages.mdx
@@ -15,8 +15,8 @@ If you know the language of the conversation in advance, specify it in the `lang
 
 If the spoken language is unknown, you can:
 
-- Omit the `language_config.languages` parameter; the model will automatically detect the language from the first few seconds of audio **across all supported languages**.
-- Specify multiple languages in the `language_config.languages` parameter; the model will detect the language from the first few seconds of audio **within the provided options**.
+- Omit the `language_config.languages` parameter; the model will automatically detect the language from the audio **across all supported languages**.
+- Specify multiple languages in the `language_config.languages` parameter; the model will detect the language from the audio **within the provided options**.
 
 <CodeGroup>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Consolidated language configuration details for real-time and pre-recorded speech-to-text APIs into a single reusable snippet.
  - Added a comprehensive "Language configuration" snippet explaining single and multiple language settings, automatic detection, and code-switching with practical examples and best practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->