### PR TITLE
[GLA-1840] fix: remove the beta warning from diarization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+.idea

--- a/chapters/pre-recorded-stt/speaker-diarization.mdx
+++ b/chapters/pre-recorded-stt/speaker-diarization.mdx
@@ -18,13 +18,6 @@ Diarization is enabled by sending the `diarization` parameter in the transcripti
 
 ## Enabling enhanced diarization (beta)
 
-<Note>
-This feature is in **Beta**.
-- It may be removed or have restricted access in the future.
-- Breaking changes could still be introduced; however, advanced notice will be provided.
-- Enabling enhanced diarization will increase transcription time.
-</Note>
-
 For improved diarization handling edge cases and challenging audio, you can enable enhanced diarization by using the `enhanced` parameter in the `diarization_config` object.
 
 ```json


### PR DESCRIPTION
![SCR-20250516-kkjv](https://github.com/user-attachments/assets/4f3a5586-8c78-48df-99da-16fe3118e645)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the speaker diarization documentation by removing the beta notice for the enhanced diarization feature.

- **Chores**
  - Updated the `.gitignore` file to exclude `.idea` project files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->