### PR TITLE
Upgrade link and wording for multichannel

### DIFF
--- a/chapters/live-stt/features.mdx
+++ b/chapters/live-stt/features.mdx
@@ -137,7 +137,7 @@ Gladia's real-time API will automatically split the channels and transcribe them
 For each utterance, you'll get a `channel` key corresponding to the channel the utterance came from.
 
 <Warning>
-  Transcribing an audio stream with multiple channels will be billed exponentially. For example, an audio stream with 2 channels will be billed as double the audio duration, even if the channels are identical.
+  Transcribing an audio stream with multiple channels is billed per channel. For example, an audio stream with 2 channels will be billed as double the audio duration, even if the channels are identical.
 </Warning>
 
 <Note>

--- a/snippets/live-flow.mdx
+++ b/snippets/live-flow.mdx
@@ -297,7 +297,7 @@ The channel numbers directly correspond to the order in which you added the audi
 </Warning>
 
 <Warning>
-  As mentioned in the [Multiple channels](#multiple-channels) section, transcribing a multi-channel audio stream will be billed based on the total duration multiplied by the number of channels.
+  As mentioned in the [Multiple channels](/chapters/live-stt/features#multiple-channels) section, transcribing a multi-channel audio stream will be billed based on the total duration multiplied by the number of channels.
 </Warning>
 
 ## Read messages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified multi-channel billing language to state billing is per channel, with an example indicating two channels count as double the audio duration.
  - Updated warning notices to reflect the clarified billing message for multi-channel setups.
  - Fixed “Multiple channels” links in Live Flow snippets to point directly to the relevant section, improving reliability of cross-page navigation.
  - No functional changes; updates focus on clarity and easier access to related information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->