### PR TITLE
Replace typeform links with a Discord links for feedback

### DIFF
--- a/chapters/audio-intelligence/pages/audio-to-llm.mdx
+++ b/chapters/audio-intelligence/pages/audio-to-llm.mdx
@@ -6,8 +6,7 @@ description: "Ask any question or analysis, as you would do with an assistant"
 <Note>
 This feature is on **Alpha** state.
 
-We're looking for feedbacks to improve this feature, [share yours here](https://gladiaio.typeform.com/feedback?typeform-source=app.gladia.io).
-
+We're looking for feedback to improve this feature, [share yours on Discord](https://discord.gg/T22a4ETUQp).
 </Note>
 
 The **Audio to LLM** feature applies your own prompts to the audio transcription.

--- a/chapters/audio-intelligence/pages/chapterization.mdx
+++ b/chapters/audio-intelligence/pages/chapterization.mdx
@@ -6,7 +6,7 @@ description: 'The Chapterization model segments the audio into distinct chapters
 This feature is in **Alpha** state.<br/>
 Breaking changes may still be introduced to this API, but an advanced notice will be sent. 
 
-We're looking for feedback to improve this feature, [share yours here](https://gladiaio.typeform.com/feedback?typeform-source=app.gladia.io).
+We're looking for feedback to improve this feature, [share yours on Discord](https://discord.gg/T22a4ETUQp).
 </Note>
 The chapterization model segments the audio 
 into logical chapters based on the audio and content, and makes it easier to navigate long audios such as meeting recordings.

--- a/chapters/audio-intelligence/pages/named-entity-recognition.mdx
+++ b/chapters/audio-intelligence/pages/named-entity-recognition.mdx
@@ -8,7 +8,7 @@ description: "The Named Entity Recognition model automatically identifies and ca
 This feature is in **Alpha** state.<br/>
 Breaking changes may still be introduced to this API, but an advanced notice will be sent. 
 
-We're looking for feedback to improve this feature, [share yours here](https://gladiaio.typeform.com/feedback?typeform-source=app.gladia.io).
+We're looking for feedback to improve this feature, [share yours on Discord](https://discord.gg/T22a4ETUQp).
 </Note>
 
 **Named Entity Recognition** (also known as  **Entity Detection**) detects and categorizes key information in the audio.

--- a/chapters/audio-intelligence/pages/summarization.mdx
+++ b/chapters/audio-intelligence/pages/summarization.mdx
@@ -6,7 +6,7 @@ description: "Get important information from your audio files"
 <Note>
 This feature is on **Beta** state.
 
-We're looking for feedbacks to improve this feature, [share yours here](https://gladiaio.typeform.com/feedback?typeform-source=app.gladia.io).
+We're looking for feedback to improve this feature, [share yours on Discord](https://discord.gg/T22a4ETUQp).
 </Note>
 
 

--- a/chapters/audio-intelligence/pages/translation.mdx
+++ b/chapters/audio-intelligence/pages/translation.mdx
@@ -6,7 +6,7 @@ description: "Translate your transcriptions & subtitles"
 <Note>
 This feature is on **Beta** state.
 
-We're looking for feedbacks to improve this feature, [share yours here](https://gladiaio.typeform.com/feedback?typeform-source=app.gladia.io).
+We're looking for feedback to improve this feature, [share yours on Discord](https://discord.gg/T22a4ETUQp).
 </Note>
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feedback notes across Audio Intelligence pages (Audio to LLM, Chapterization, Named Entity Recognition, Summarization, Translation).
  * Replaced Typeform feedback links with a Discord invite and refined wording (e.g., “feedbacks” → “feedback”, “here” → “on Discord”).
  * Improves clarity and guides users to our community channel for sharing feedback.
  * No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->