### PR TITLE
Add partial transcript to the real-time API V2 features page

### DIFF
--- a/chapters/live-stt/features.mdx
+++ b/chapters/live-stt/features.mdx
@@ -50,14 +50,14 @@ Under each utterance, you'll find a `words` property, like this:
 
 ## Partial transcripts
 
-Partial transcripts provide a word-by-word streaming transcription as words are spoken, offering immediate insights before the final, high-accuracy transcript is ready. [c] While these intermediate results are subject to change, they are essential for use cases like Voice AI Agents where low latency is critical.
+Partial transcripts provide a low-latency streaming transcription as words are spoken, offering immediate insights before the final, high-accuracy transcript is ready. While these intermediate results are subject to change, they are essential for use cases like Voice AI Agents where low latency is critical.
 
-By processing partial transcripts as they arrive, a voice agent can understand user intent faster—often from the first few words (e.g., "Stop, this is not...")—and begin generating a response more quickly. [c] This significantly reduces the total response time and creates a more fluid user experience. [c] To achieve this speed, partial transcripts use a faster, smaller model than the one used for final transcripts, trading a small amount of accuracy for a large gain in latency. [k]
-Configuration
+By processing partial transcripts as they arrive, a voice agent can understand user intent faster—often from the first few words (e.g., "Stop, this is not...") and begin generating a response more quickly. 
+This significantly reduces the total response time and creates a more fluid user experience. 
+To achieve this speed, partial transcripts use a faster, smaller model than the one used for final transcripts, trading a small amount of accuracy for a large gain in latency.
 
-Partial transcripts are not returned by default. To enable them, you must add the receive_partial_transcripts property to the messages_config object in your request.
 
-Here is an example of a configuration with partial transcripts enabled:
+To enable the partial transcripts, you must add the `receive_partial_transcripts` property to the `messages_config` object in your request.
 
 ```json
 {
@@ -77,15 +77,15 @@ Here is an example of a configuration with partial transcripts enabled:
 ```
   
 With this configuration, you will receive both the partial transcripts as they are generated and the final, most accurate version of each utterance.
-Transcript Message
 
-When you set receive_partial_transcripts to true, the real-time API will send transcript messages for both intermediate and final results. To distinguish between them, the message payload includes the is_final boolean field.
+When you set `receive_partial_transcripts` to `true`, the real-time API will send transcript messages for both intermediate and final results. 
+To distinguish between them, the message payload includes the [`is_final`](https://docs.gladia.io/api-reference/v2/live/message/transcript#schema-data-is-final) boolean field.
 
 - `"is_final": false`: The message contains a partial transcript, which is subject to change.
 
 - `"is_final": true`: The message contains the final, most accurate transcript for an utterance. This transcript will not change.
 
-For a detailed breakdown of the API response, please consult the Transcript Message API Reference.
+<Note>We recommend limiting the number of languages when using partials, as the minimal audio context makes language detection more sensitive.</Note>
 
 ## Custom vocabulary
 

--- a/chapters/live-stt/features.mdx
+++ b/chapters/live-stt/features.mdx
@@ -48,6 +48,45 @@ Under each utterance, you'll find a `words` property, like this:
 }
 ```
 
+## Partial transcripts
+
+Partial transcripts provide a word-by-word streaming transcription as words are spoken, offering immediate insights before the final, high-accuracy transcript is ready. [c] While these intermediate results are subject to change, they are essential for use cases like Voice AI Agents where low latency is critical.
+
+By processing partial transcripts as they arrive, a voice agent can understand user intent faster—often from the first few words (e.g., "Stop, this is not...")—and begin generating a response more quickly. [c] This significantly reduces the total response time and creates a more fluid user experience. [c] To achieve this speed, partial transcripts use a faster, smaller model than the one used for final transcripts, trading a small amount of accuracy for a large gain in latency. [k]
+Configuration
+
+Partial transcripts are not returned by default. To enable them, you must add the receive_partial_transcripts property to the messages_config object in your request.
+
+Here is an example of a configuration with partial transcripts enabled:
+
+```json
+{
+    "encoding": "wav/pcm",
+    "sample_rate": 16000,
+    "bit_depth": 16,
+    "channels": 1,
+    "language_config": {
+        "languages": ["es"],
+        "code_switching": true
+    },
+    "messages_config": {
+        "receive_partial_transcripts": true,
+        "receive_final_transcripts": true
+    }
+}
+```
+  
+With this configuration, you will receive both the partial transcripts as they are generated and the final, most accurate version of each utterance.
+Transcript Message
+
+When you set receive_partial_transcripts to true, the real-time API will send transcript messages for both intermediate and final results. To distinguish between them, the message payload includes the is_final boolean field.
+
+- `"is_final": false`: The message contains a partial transcript, which is subject to change.
+
+- `"is_final": true`: The message contains the final, most accurate transcript for an utterance. This transcript will not change.
+
+For a detailed breakdown of the API response, please consult the Transcript Message API Reference.
+
 ## Custom vocabulary
 
 To enhance the precision of words you know will recur often in your transcription, use the `custom_vocabulary` feature.<br />

--- a/chapters/live-stt/features.mdx
+++ b/chapters/live-stt/features.mdx
@@ -50,12 +50,7 @@ Under each utterance, you'll find a `words` property, like this:
 
 ## Partial transcripts
 
-Partial transcripts provide a low-latency streaming transcription as words are spoken, offering immediate insights before the final, high-accuracy transcript is ready. While these intermediate results are subject to change, they are essential for use cases like Voice AI Agents where low latency is critical.
-
-By processing partial transcripts as they arrive, a voice agent can understand user intent faster—often from the first few words (e.g., "Stop, this is not...") and begin generating a response more quickly. 
-This significantly reduces the total response time and creates a more fluid user experience. 
-To achieve this speed, partial transcripts use a faster, smaller model than the one used for final transcripts, trading a small amount of accuracy for a large gain in latency.
-
+Partial transcripts provide a low-latency streaming transcription as words are spoken, offering immediate insights before the final, high-accuracy transcript is ready.
 
 To enable the partial transcripts, you must add the `receive_partial_transcripts` property to the `messages_config` object in your request.
 
@@ -67,7 +62,7 @@ To enable the partial transcripts, you must add the `receive_partial_transcripts
     "channels": 1,
     "language_config": {
         "languages": ["es"],
-        "code_switching": true
+        "code_switching": false
     },
     "messages_config": {
         "receive_partial_transcripts": true,
@@ -78,6 +73,10 @@ To enable the partial transcripts, you must add the `receive_partial_transcripts
   
 With this configuration, you will receive both the partial transcripts as they are generated and the final, most accurate version of each utterance.
 
+To reduce the total response time and create a more fluid user experience, partial transcripts use a faster, smaller model than the one used for final transcripts, trading a small amount of accuracy for a large gain in latency (< 100ms).
+
+<Note>Partial transcripts accuracy deteriorates when multiple languages and/or code switching are enabled. For best results, we recommend to limit the number of languages.</Note>
+
 When you set `receive_partial_transcripts` to `true`, the real-time API will send transcript messages for both intermediate and final results. 
 To distinguish between them, the message payload includes the [`is_final`](https://docs.gladia.io/api-reference/v2/live/message/transcript#schema-data-is-final) boolean field.
 
@@ -85,7 +84,9 @@ To distinguish between them, the message payload includes the [`is_final`](https
 
 - `"is_final": true`: The message contains the final, most accurate transcript for an utterance. This transcript will not change.
 
-<Note>We recommend limiting the number of languages when using partials, as the minimal audio context makes language detection more sensitive.</Note>
+In a same utterance, the partial and final transcripts share the same `data.id`.
+
+
 
 ## Custom vocabulary
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added “Partial transcripts” under Word-level timestamps.
  * Describes low-latency, word-by-word streaming transcripts and accuracy/latency tradeoffs.
  * Shows how to enable delivery of both interim (partial) and final transcripts (with example).
  * Explains transcript messages indicate interim vs final results and share the same utterance identifier.
  * Provides language-selection guidance for best accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->