### PR TITLE
fixed main page redirection

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -341,7 +341,7 @@
     },
     {
       "source": "/chapters/introduction/pages/introduction",
-      "destination": "/chapters/introduction/introduction"
+      "destination": "/chapters/introduction"
     },
     {
       "source": "/chapters/introduction/pages/why-use-gladia",


### PR DESCRIPTION
Fixed main page redirection link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated docs navigation mapping for the Introduction page: the source "/chapters/introduction/pages/introduction" now redirects to "/chapters/introduction" instead of "/chapters/introduction/introduction".
  * End-users will land on the Introduction section root when navigating from that page.
  * No other documentation routes or navigation behaviors were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->