### PR TITLE
Add redirection for API reference introduction

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -466,6 +466,10 @@
     {
       "source": "/chapters/limits-and-specifications/languages",
       "destination": "/chapters/language/supported-languages"
+    },
+    {
+      "source": "/api-reference/introduction",
+      "destination": "/api-reference"
     }
   ]
 }


### PR DESCRIPTION
Add redirection from api-reference old intro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Introduced a redirect that sends visits to the former API Reference introduction URL to the main API Reference page. This ensures old or bookmarked links continue to work, eliminates potential 404s, and streamlines navigation within the documentation. Improves SEO and reduces broken link reports for readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->