### PR TITLE
update latency description for partial transcripts

### DIFF
--- a/chapters/live-stt/features/partial-transcripts.mdx
+++ b/chapters/live-stt/features/partial-transcripts.mdx
@@ -26,7 +26,7 @@ To enable partial transcripts, add the `receive_partial_transcripts` property to
 
 With this configuration, you will receive both partial transcripts as they are generated and the final, most accurate version of each utterance.
 
-To reduce the total response time and create a more fluid user experience, partial transcripts use a faster, smaller model than the one used for final transcripts, trading a small amount of accuracy for a large gain in latency (< 100ms).
+To reduce the total response time and create a more fluid user experience, partial transcripts use a faster, smaller model than the one used for final transcripts, trading a small amount of accuracy for a large gain in latency.
 
 <Note>Partial transcripts accuracy deteriorates when multiple languages and/or code switching are enabled. For best results, limit the number of languages.</Note>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified how real-time partial vs. final transcripts are indicated when partial transcripts are enabled, introducing the is_final flag (false for partial, true for final).
  - Specified that partial and final transcripts for the same utterance share the same data.id.
  - Removed the explicit latency claim (“< 100ms”) and references to latency gains from smaller models to avoid misleading expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->