### PR TITLE
Remove height attribute from dark banner image in introduction chapter

### DIFF
--- a/chapters/introduction/index.mdx
+++ b/chapters/introduction/index.mdx
@@ -9,7 +9,6 @@ import IntegrationsCards from '/snippets/integrations-cards.mdx';
 <img 
   className="block dark:hidden rounded-lg" 
   noZoom
-  height="10"
   src="/assets/dark-banner.png" 
 />
 <img 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated introduction banner image display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->