### PR TITLE
docs: align diarization config field name with openapi

### DIFF
--- a/chapters/pre-recorded-stt/features/speaker-diarization.mdx
+++ b/chapters/pre-recorded-stt/features/speaker-diarization.mdx
@@ -46,7 +46,7 @@ Speakers will be assigned indexes by **order of appearance** (i.e. the 1st speak
 
 ## Improving diarization accuracy
 
-You can improve the accuracy of the diarization by providing the model with hints regarding the expected number or lower/upper bounds ofspeakers using the `diarization_config.num_of_speakers`, `diarization_config.min_speakers` and `diarization_config.max_speakers`  parameters respectively.
+You can improve the accuracy of the diarization by providing the model with hints regarding the expected number or lower/upper bounds of speakers using the `diarization_config.number_of_speakers`, `diarization_config.min_speakers` and `diarization_config.max_speakers` parameters respectively.
 
 **Important:** These parameters are hints, not hard constraints. The actual number of speakers detected by the model may not comply with the provided parameters.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated speaker diarization configuration documentation to reflect the correct field naming convention for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->