### PR TITLE
fix: clarify and shorten the doc custom spelling and custom vocab

### DIFF
--- a/chapters/audio-intelligence/custom-spelling.mdx
+++ b/chapters/audio-intelligence/custom-spelling.mdx
@@ -10,9 +10,9 @@ import VocabularyVsSpelling from "/snippets/custom-vocabulary-vs-spelling.mdx";
 <PrerecordedBadge />
 <LiveBadge />
 
-As Speech-to-text models are trained on general vocabulary, under-represented words such brand names, proper nouns, and domain-specific terms are often transcribed incorrectly. That is why we use **custom spelling** at Gladia.
+As Speech-to-text models are trained on general vocabulary, under-represented words such as brand names, proper nouns, or domain-specific terms are often transcribed incorrectly. That is why we use **custom spelling** at Gladia.
 
-Custom Spelling is a post-processing operation that applies literal matching between the correct word and the pronunciations entries. When the literal match is close enough, the transcribed text is replaced with your term.
+Custom Spelling is a post-processing operation that applies literal matching between the correct word and the pronunciations entries. When there is a literal match, the transcribed text is replaced with your term.
 
 <Note>
   If the word comes out garbled or replaced by something phonetically similar (e.g.
@@ -38,7 +38,7 @@ Custom spelling is **precise but strict**: Gladia replaces only strings listed i
 If the model outputs **"gaurish"** or **"ghorish"**, Gladia replaces them with **"Gorish"** when they appear in your dictionary:
 
 ```json
-"Gorish": ["ghorish", "gaurish", "gaureish" "geurish", "go rich"]
+"Gorish": ["ghorish", "gaurish", "gaureish", "geurish", "go rich"]
 ```
 
 Custom spelling is not based on phoneme-matching but **literal matching** so make sure to list every spelling carefully as missing variants are never inferred.
@@ -55,7 +55,7 @@ Custom spelling is not based on phoneme-matching but **literal matching** so mak
   "custom_spelling": true,
   "custom_spelling_config": {
     "spelling_dictionary": {
-      "Gorish": ["ghorish", "gaurish", "gaureish" "geurish", "go rich"],
+      "Gorish": ["ghorish", "gaurish", "gaureish", "geurish", "go rich"],
       "Data Science": ["data-science", "data science"],
       ".": ["period", "full stop"],
       "SQL": ["sequel"]
@@ -69,7 +69,7 @@ Custom spelling is not based on phoneme-matching but **literal matching** so mak
     "custom_spelling": true,
     "custom_spelling_config": {
       "spelling_dictionary": {
-        "Gorish": ["ghorish", "gaurish", "gaureish" "geurish", "go rich"],
+        "Gorish": ["ghorish", "gaurish", "gaureish", "geurish", "go rich"],
         "Data Science": ["data-science", "data science"],
         ".": ["period", "full stop"],
         "SQL": ["sequel"]

--- a/chapters/audio-intelligence/custom-spelling.mdx
+++ b/chapters/audio-intelligence/custom-spelling.mdx
@@ -3,24 +3,47 @@ title: "Custom spelling"
 description: "Normalize spelling variants to your preferred forms"
 ---
 
-import PrerecordedBadge from "/snippets/badges/prerecorded.mdx"
-import LiveBadge from "/snippets/badges/live.mdx"
-import VocabularyVsSpelling from "/snippets/custom-vocabulary-vs-spelling.mdx"
+import PrerecordedBadge from "/snippets/badges/prerecorded.mdx";
+import LiveBadge from "/snippets/badges/live.mdx";
+import VocabularyVsSpelling from "/snippets/custom-vocabulary-vs-spelling.mdx";
 
 <PrerecordedBadge />
 <LiveBadge />
 
-Custom spelling lets you **force specific text replacements** in the final transcript. You provide a dictionary where each key is the spelling you want, and each value is a list of variants the model might produce instead. When any of those variants appear in the transcript, they get replaced with no ambiguity and no false positives.
+As Speech-to-text models are trained on general vocabulary, under-represented words such brand names, proper nouns, and domain-specific terms are often transcribed incorrectly. That is why we use **custom spelling** at Gladia.
 
-This is a straightforward **text-based find-and-replace** on the transcript output. It doesn't look at how words sound; it matches the exact strings you list.
+Custom Spelling is a post-processing operation that applies literal matching between the correct word and the pronunciations entries. When the literal match is close enough, the transcribed text is replaced with your term.
+
+<Note>
+  If the word comes out garbled or replaced by something phonetically similar (e.g.
+  **"le vin"** instead of **"Levain"**), use **[Custom
+  vocabulary](/chapters/audio-intelligence/custom-vocabulary)** instead. Custom
+  vocabulary matches on phonemes, not literal text.
+</Note>
 
 ## How it works
 
-After the transcription is generated, Gladia scans the output text for any of the variant strings you listed as dictionary values. When it finds one, it swaps it for the corresponding key. The matching is **deterministic**: if the text is there, it gets replaced; if it isn't, nothing happens.
+Gladia runs custom spelling on the **transcript text** after transcription:
 
-Keys (replacement to write) are case sensitive. Values (variants to find) are not. Values can contain multiple words.
+1. Gladia scans the output for strings listed in your dictionary **values**.
+2. When a variant is found, it is replaced with the corresponding **key**.
+3. Each entry supplies:
+   - **Key** — the spelling to write (case-sensitive).
+   - **Values** — variant strings to find (case-insensitive; can be multiple words).
 
-## When to use custom spelling vs. custom vocabulary
+Custom spelling is **precise but strict**: Gladia replaces only strings listed in your dictionary and leaves everything else unchanged. 
+
+### Example: name "Gorish"
+
+If the model outputs **"gaurish"** or **"ghorish"**, Gladia replaces them with **"Gorish"** when they appear in your dictionary:
+
+```json
+"Gorish": ["ghorish", "gaurish", "gaureish" "geurish", "go rich"]
+```
+
+Custom spelling is not based on phoneme-matching but **literal matching** so make sure to list every spelling carefully as missing variants are never inferred.
+
+## When to use custom vocabulary vs. custom spelling
 
 <VocabularyVsSpelling />
 
@@ -32,7 +55,7 @@ Keys (replacement to write) are case sensitive. Values (variants to find) are no
   "custom_spelling": true,
   "custom_spelling_config": {
     "spelling_dictionary": {
-      "Gorish": ["ghorish", "gaurish", "gaureish"],
+      "Gorish": ["ghorish", "gaurish", "gaureish" "geurish", "go rich"],
       "Data Science": ["data-science", "data science"],
       ".": ["period", "full stop"],
       "SQL": ["sequel"]
@@ -46,7 +69,7 @@ Keys (replacement to write) are case sensitive. Values (variants to find) are no
     "custom_spelling": true,
     "custom_spelling_config": {
       "spelling_dictionary": {
-        "Gorish": ["ghorish", "gaurish", "gaureish"],
+        "Gorish": ["ghorish", "gaurish", "gaureish" "geurish", "go rich"],
         "Data Science": ["data-science", "data science"],
         ".": ["period", "full stop"],
         "SQL": ["sequel"]
@@ -57,13 +80,30 @@ Keys (replacement to write) are case sensitive. Values (variants to find) are no
 ```
 </CodeGroup>
 
-In this example, any time the model outputs "ghorish", "gaurish", or "gaureish", it will be replaced with "Gorish" in the final transcript. Similarly, "sequel" becomes "SQL", and spoken words like "period" or "full stop" become a literal ".".
+## Parameter reference
 
-## How to build your spelling dictionary
+<ParamField body="spelling_dictionary" type="object">
+  Map of preferred spellings (**keys**) to variant strings the model might output (**values**).
+    <ParamField body="key" type="string" required>
+      The correct word to transcribe. This parameter is **case-sensitive** so `"Gorish"` and `"gorish"` are different keys.
+    </ParamField>
 
-1. **Run a transcription without custom spelling** and review the output.
-2. **Identify words that are close but not quite right.** These are your candidates.
-3. **Add each correct spelling as a key**, and list every variant you've seen the model produce as values.
-4. **Run again** and verify the replacements look correct.
+    <ParamField body="values" type="string[]" required>
+      Variant strings to search for in the transcript. Those strings are **case-insensitive.** and can be multiple words (e.g. `"full stop"`).
+    </ParamField>
+</ParamField>
 
-You don't need to guess at variants upfront. Just collect them from real transcription outputs over time and add them to your dictionary as they appear.
+## Tuning tips
+
+- **Collect variants from real transcripts** — run without custom spelling first, then add keys and values from what the model actually outputs.
+- **Match key capitalization** to how the word should appear in the final transcript.
+- **List phonetically different strings separately** — custom spelling will not group them the way custom vocabulary does.
+- **Move garbled or sound-alike output to [custom vocabulary](/chapters/audio-intelligence/custom-vocabulary)** when listing every variant becomes impractical.
+
+## Recommended workflow
+
+1. **Transcribe without custom spelling** and note misspelled terms.
+2. **Route each term:** recognizable but wrong spelling → custom spelling; garbled or phonetically wrong → custom vocabulary.
+3. **Build the dictionary** — correct form as the key, every variant you have seen as values.
+4. **Transcribe again** — confirm replacements and check that nothing else was changed unexpectedly.
+5. **Refine:** add new variants as they appear in production audio.

--- a/chapters/audio-intelligence/custom-spelling.mdx
+++ b/chapters/audio-intelligence/custom-spelling.mdx
@@ -10,7 +10,7 @@ import VocabularyVsSpelling from "/snippets/custom-vocabulary-vs-spelling.mdx";
 <PrerecordedBadge />
 <LiveBadge />
 
-As Speech-to-text models are trained on general vocabulary, under-represented words such as brand names, proper nouns, or domain-specific terms are often transcribed incorrectly. That is why we use **custom spelling** at Gladia.
+As Speech-to-text models are trained on general vocabulary, under-represented words such as brand names, proper nouns, or domain-specific terms are often transcribed incorrectly.
 
 Custom Spelling is a post-processing operation that applies literal matching between the correct word and the pronunciations entries. When there is a literal match, the transcribed text is replaced with your term.
 
@@ -83,6 +83,8 @@ Custom spelling is not based on phoneme-matching but **literal matching** so mak
 ## Parameter reference
 
 <ParamField body="spelling_dictionary" type="object">
+  <Expandable title="properties">
+
   Map of preferred spellings (**keys**) to variant strings the model might output (**values**).
     <ParamField body="key" type="string" required>
       The correct word to transcribe. This parameter is **case-sensitive** so `"Gorish"` and `"gorish"` are different keys.
@@ -91,6 +93,8 @@ Custom spelling is not based on phoneme-matching but **literal matching** so mak
     <ParamField body="values" type="string[]" required>
       Variant strings to search for in the transcript. Those strings are **case-insensitive.** and can be multiple words (e.g. `"full stop"`).
     </ParamField>
+  </Expandable>
+  
 </ParamField>
 
 ## Tuning tips

--- a/chapters/audio-intelligence/custom-vocabulary.mdx
+++ b/chapters/audio-intelligence/custom-vocabulary.mdx
@@ -10,7 +10,7 @@ import VocabularyVsSpelling from "/snippets/custom-vocabulary-vs-spelling.mdx";
 <PrerecordedBadge />
 <LiveBadge />
 
-As Speech-to-text models are trained on general vocabulary, under-represented words such brand names, proper nouns, and domain-specific terms are often transcribed incorrectly. That is why we use **custom vocabulary** at Gladia.
+As Speech-to-text models are trained on general vocabulary, under-represented words such as brand names, proper nouns, or domain-specific terms are often transcribed incorrectly. That is why we use **custom vocabulary** at Gladia.
 
 Custom Vocabulary is a post-processing operation that compares **phonemes** between the transcript and your pronunciations entries. When the phonetic match is close enough, the transcribed text is replaced with your term.
 
@@ -43,7 +43,7 @@ If the transcript contains **"le vin"** or **"levin"**, Gladia can replace them 
 }
 ```
 
-For example, the pronunciations will be convert to the phonemes _'lɛvɪn'_, _'le vɪn'_ and _'ləˈvin'_, and will be replace by the correct word **'Levin'** with the phoneme _'lɛvɪn'_.
+For example, the pronunciations entries will be convert to the phonemes _'lɛvɪn'_, _'le vɪn'_ and _'ləˈvin'_, and will be replace by the correct word **'Levin'**.
 
 
 ## When to use custom vocabulary vs. custom spelling

--- a/chapters/audio-intelligence/custom-vocabulary.mdx
+++ b/chapters/audio-intelligence/custom-vocabulary.mdx
@@ -10,25 +10,41 @@ import VocabularyVsSpelling from "/snippets/custom-vocabulary-vs-spelling.mdx";
 <PrerecordedBadge />
 <LiveBadge />
 
-Custom vocabulary helps the transcription engine **recognize words it would otherwise get wrong**: unusual brand names, internal project codenames, medical or legal jargon, or acronyms that sound like common words.
+As Speech-to-text models are trained on general vocabulary, under-represented words such brand names, proper nouns, and domain-specific terms are often transcribed incorrectly. That is why we use **custom vocabulary** at Gladia.
 
-It works by comparing the _sounds_ (phonemes) of what was actually spoken against the sounds of the words you provide. When there's a close enough match, the transcribed word gets swapped out for your term. This is **probabilistic**: it increases the odds of a correct transcription, but it does not guarantee it.
+Custom Vocabulary is a post-processing operation that compares **phonemes** between the transcript and your pronunciations entries. When the phonetic match is close enough, the transcribed text is replaced with your term.
 
 <Note>
-  If you already know exactly which *text* variants the model produces and you
-  just want to normalize the spelling, use **[Custom
-  spelling](/chapters/audio-intelligence/custom-spelling)** instead. Custom
-  spelling is a deterministic find-and-replace on the transcript text, with no
-  phoneme matching and no false positives.
+  If you already know which *text* variants the model produces and only need to
+  normalize spelling, use **[Custom
+  spelling](/chapters/audio-intelligence/custom-spelling)** instead. Custom-spelling is not based on phonemes but literal matching.
 </Note>
 
 ## How it works
 
-Custom vocabulary operates at a **text level** and is based on **phoneme similarity**.
+Gladia runs custom vocabulary on the **transcript text** after transcription:
 
-Once the transcription is generated, Gladia converts both the transcribed words and your vocabulary entries into phonemes, then compares them. The `intensity` controls how aggressively the model applies replacements: a higher intensity means the model will replace words more readily (wider phoneme matching), while a lower intensity requires a closer phoneme match before a replacement is made.
+1. Transcribed words and your entries are converted to phonemes.
+2. Gladia applies replacements when the match score (fuzzy-matching) is within the configured threshold.
+3. Each entry supplies:
+   - **`value`** — the correct word to be transcribed
+   - **`pronunciations`** — 2–3 words with different spelling for how the word might be mis-transcribed
+   - **`intensity`** — how strict the match must be (0–1). Higher values catch more variants but increase false positives.
 
-The `pronunciations` field lets you provide **plain-text alternative spellings that reflect how the word actually sounds** in speech. These are _not_ phonetic notation. Just write the word the way someone might naively spell it based on how it sounds. Gladia converts these strings to phonemes internally. For example, if your term is "Nietzsche", you might add `["Niche", "Neechee"]` as pronunciations. This widens the phoneme net without having to raise the intensity (which would increase false positives across the board).
+### Example: brand name "Levain"
+
+If the transcript contains **"le vin"** or **"levin"**, Gladia can replace them with **"Levain"** when the entry is configured well:
+
+```json
+{
+  "value": "Levain",
+  "pronunciations": ["levin", "le vin", "levine"],
+  "intensity": 0.4
+}
+```
+
+For example, the pronunciations will be convert to the phonemes _'lɛvɪn'_, _'le vɪn'_ and _'ləˈvin'_, and will be replace by the correct word **'Levin'** with the phoneme _'lɛvɪn'_.
+
 
 ## When to use custom vocabulary vs. custom spelling
 
@@ -80,68 +96,40 @@ The `pronunciations` field lets you provide **plain-text alternative spellings t
 
 ## Parameter reference
 
-<ParamField body="default_intensity" type="number">
-  The global intensity applied to every vocabulary entry that doesn't have its own `intensity` override (minimum 0, maximum 1, default 0.5).
-
-A higher value means the model will apply replacements more aggressively: more replacements, but more risk of unwanted swaps. A lower value requires a closer phoneme match before replacing: fewer replacements, fewer false positives.
-
-</ParamField>
 <ParamField body="vocabulary" type="object | string[]">
-  <Expandable title="properties">
     <ParamField body="value" type="string" required>
-      The text that will be inserted into the transcription when a phoneme match is found.
+      The correct word you want to be transcribed.
     </ParamField>
     
     <ParamField body="pronunciations" type="string[]">
-      Plain-text alternative spellings that reflect how the word sounds in speech. Write them the way someone would naively spell the word based on pronunciation. Gladia converts these to phonemes internally. This is *not* phonetic notation.
+      Words with different spellings the word might be mis-spelled or mis-transcribed.
     </ParamField>
 
     <ParamField body="intensity" type="number">
-      The intensity for this specific entry (minimum 0, maximum 1, default: inherits from `default_intensity`). Use this to make individual entries more or less aggressive than the global default. For example, set a lower intensity on a short word that keeps producing false positives.
+      Per-entry intensity, we suggest **0.4–0.6** as value.
+      Inherits `default_intensity` when omitted. 
     </ParamField>
 
     <ParamField body="language" type="string">
-      The language in which this word will be pronounced during phoneme comparison. Defaults to the transcription language. This matters when a word from one language appears in a conversation in another language. For example, an English brand name like "Salesforce" spoken in a French meeting. Setting `language: "en"` ensures the phoneme comparison uses English pronunciation rules, not French ones.
+      Language used for phoneme comparison (defaults to the transcription language). Set this when a term is pronounced in a different language than the rest of the audio.
     </ParamField>
 
-  </Expandable>
+  <ParamField body="default_intensity" type="number">
+  Global intensity for entries. We suggest **0.4–0.6** raise if terms are missed, lower if unrelated words get replaced.
+</ParamField>
 </ParamField>
 
-## Tuning intensity
+## Tuning tips
 
-The default intensity is **0.5**, which works well for short lists of very distinctive words. But in practice, especially with longer lists or shorter words, 0.5 is often too aggressive and produces false positives.
-
-**We recommend starting at 0.4** and raising only if you notice that your terms are still not being picked up, or lowering if you see too many false positives.
-
-### `default_intensity` vs. per-entry `intensity`
-
-- `default_intensity` sets the baseline for every entry in your vocabulary list.
-- The per-entry `intensity` field overrides the global default for that specific word.
-
-You can mix both. A common pattern: set `default_intensity` to 0.4, then lower individual short or common-sounding words (like brand names "Target" or "Zoom") down to 0.2-0.3 to avoid them matching too many unrelated words.
-
-### Watch your list size
-
-As your vocabulary list grows, the chance of false positives increases. Every transcribed word is compared against every entry, so a list of 50+ terms will naturally produce more unintended replacements than a list of 5.
-
-If you find yourself fighting false positives on a large list, consider:
-
-1. Lowering the intensity for the entries that cause problems.
-2. Adding specific `pronunciations` to narrow the phoneme matching instead of lowering intensity.
-3. Moving entries that the model already recognizes (just with wrong spelling) to **[custom spelling](/chapters/audio-intelligence/custom-spelling)** instead. This eliminates false positives entirely for those terms.
+- **Start at `default_intensity` 0.4** and adjust per entry only when needed.
+- **Add `pronunciations` before raising `intensity`** — variants narrow what can match without loosening every comparison.
+- **Keep lists focused** — every transcribed word is compared against every entry; long lists increase false positives.
+- **Move stable misspellings to [custom spelling](/chapters/audio-intelligence/custom-spelling)** when the model already outputs a recognizable (but wrong) form.
 
 ## Recommended workflow
 
-If you're setting up custom vocabulary for the first time, here's a step-by-step approach that will save you time:
-
-1. **Run a transcription without any custom vocabulary.** Look at the raw output and identify which words are being mis-transcribed.
-2. **Separate the problems into two buckets:**
-   - Words that are completely wrong or garbled → these are candidates for **custom vocabulary**.
-   - Words that are recognizable but misspelled (e.g. "Gaurish" instead of "Gorish") → use **[custom spelling](/chapters/audio-intelligence/custom-spelling)** for these.
-3. **Add your custom vocabulary entries** with `default_intensity` set to **0.4**.
-4. **Run the transcription again** and compare. Check that your terms are now appearing correctly.
-5. **Look for false positives**, words that were correct before but are now being wrongly replaced. If you spot any:
-   - Lower the `intensity` on the entry causing the problem.
-   - Add `pronunciations` to make the match more precise.
-   - If false positives persist, move that entry to custom spelling instead.
-6. **Iterate.** Tuning is normal. Don't expect to get it perfect on the first pass.
+1. **Transcribe without custom vocabulary** and note mis-transcribed terms.
+2. **Route each term:** garbled or phonetically wrong output → custom vocabulary; recognizable but misspelled → custom spelling.
+3. **Add entries** with `pronunciations` and `default_intensity` around **0.4–0.6**.
+4. **Transcribe again** — confirm targets appear and scan for false positives.
+5. **Refine:** lower `intensity`, tighten `pronunciations`, or move stubborn terms to custom spelling.

--- a/chapters/audio-intelligence/custom-vocabulary.mdx
+++ b/chapters/audio-intelligence/custom-vocabulary.mdx
@@ -10,41 +10,23 @@ import VocabularyVsSpelling from "/snippets/custom-vocabulary-vs-spelling.mdx";
 <PrerecordedBadge />
 <LiveBadge />
 
-As Speech-to-text models are trained on general vocabulary, under-represented words such as brand names, proper nouns, or domain-specific terms are often transcribed incorrectly. That is why we use **custom vocabulary** at Gladia.
+As Speech-to-text models are trained on general vocabulary, under-represented words such as brand names, proper nouns, or domain-specific terms are often transcribed incorrectly.
 
 Custom Vocabulary is a post-processing operation that compares **phonemes** between the transcript and your pronunciations entries. When the phonetic match is close enough, the transcribed text is replaced with your term.
 
 <Note>
   If you already know which *text* variants the model produces and only need to
   normalize spelling, use **[Custom
-  spelling](/chapters/audio-intelligence/custom-spelling)** instead. Custom-spelling is not based on phonemes but literal matching.
+  spelling](/chapters/audio-intelligence/custom-spelling)** instead. Custom spelling is not based on phonemes but literal matching.
 </Note>
 
 ## How it works
 
-Gladia runs custom vocabulary on the **transcript text** after transcription:
+Custom vocabulary operates at a **text level** and is based on **phoneme similarity**.
 
-1. Transcribed words and your entries are converted to phonemes.
-2. Gladia applies replacements when the match score (fuzzy-matching) is within the configured threshold.
-3. Each entry supplies:
-   - **`value`** — the correct word to be transcribed
-   - **`pronunciations`** — 2–3 words with different spelling for how the word might be mis-transcribed
-   - **`intensity`** — how strict the match must be (0–1). Higher values catch more variants but increase false positives.
+Once the transcription is generated, Gladia converts both the transcribed words and your vocabulary entries into phonemes, then compares them. The `intensity` controls how aggressively the model applies replacements: a higher intensity means the model will replace words more readily (wider phoneme matching), while a lower intensity requires a closer phoneme match before a replacement is made.
 
-### Example: brand name "Levain"
-
-If the transcript contains **"le vin"** or **"levin"**, Gladia can replace them with **"Levain"** when the entry is configured well:
-
-```json
-{
-  "value": "Levain",
-  "pronunciations": ["levin", "le vin", "levine"],
-  "intensity": 0.4
-}
-```
-
-For example, the pronunciations entries will be convert to the phonemes _'lɛvɪn'_, _'le vɪn'_ and _'ləˈvin'_, and will be replace by the correct word **'Levin'**.
-
+The `pronunciations` field lets you provide **plain-text alternative spellings that reflect how the word actually sounds** in speech. These are _not_ phonetic notation. Just write the word the way someone might naively spell it based on how it sounds. Gladia converts these strings to phonemes internally. For example, if your term is "Nietzsche", you might add `["Niche", "Neechee"]` as pronunciations. This widens the phoneme net without having to raise the intensity (which would increase false positives across the board).
 
 ## When to use custom vocabulary vs. custom spelling
 
@@ -97,6 +79,7 @@ For example, the pronunciations entries will be convert to the phonemes _'lɛvɪ
 ## Parameter reference
 
 <ParamField body="vocabulary" type="object | string[]">
+  <Expandable title="properties">
     <ParamField body="value" type="string" required>
       The correct word you want to be transcribed.
     </ParamField>
@@ -113,7 +96,8 @@ For example, the pronunciations entries will be convert to the phonemes _'lɛvɪ
     <ParamField body="language" type="string">
       Language used for phoneme comparison (defaults to the transcription language). Set this when a term is pronounced in a different language than the rest of the audio.
     </ParamField>
-
+  </Expandable>
+  
   <ParamField body="default_intensity" type="number">
   Global intensity for entries. We suggest **0.4–0.6** raise if terms are missed, lower if unrelated words get replaced.
 </ParamField>

--- a/snippets/custom-vocabulary-vs-spelling.mdx
+++ b/snippets/custom-vocabulary-vs-spelling.mdx
@@ -1,27 +1,10 @@
-Use **[custom spelling](/chapters/audio-intelligence/custom-spelling)** when the transcription already _recognizes_ the word but writes it differently than you want. Common cases:
+**[Custom spelling](/chapters/audio-intelligence/custom-spelling)** fixes the transcription when the model always outputs a close textual match (e.g. **"data-science"** → **"Data Science"**). It applies **literal matching** on strings you list. Make sure to add every possible close words variants.
 
-- A person's name comes through as "Gaurish" or "Gaureish" but you need "Gorish".
-- The model writes "data-science" and you want "Data Science".
-- You want to replace filler words or normalize punctuation (e.g. "period" → ".").
+**[Custom vocabulary](/chapters/audio-intelligence/custom-vocabulary)** fixes garbled or sound-alike output (e.g. **"le vin"** / **"levine"** → **"Levain"**). It applies **phonemes matching** on strings you list. Entries must cover to potential different spellings of the words.
 
-Use **[custom vocabulary](/chapters/audio-intelligence/custom-vocabulary)** when the word comes out completely garbled or replaced by something phonetically similar. The transcription engine has never seen it and can't get close on its own. Custom vocabulary uses phoneme matching to catch these cases, but it's probabilistic and can produce false positives.
+| | Custom spelling | Custom vocabulary |
+| --- | --- | --- |
+| **Matches on** | Exact text in the transcript	 | How words sound |
+| **Best for** | Wrong spelling, punctuation, formatting | Phonetically similar mis-transcriptions |
+| **You provide** | All the words that the model outputs wrongly | `value`, `pronunciations`, `intensity` |
 
-|                  | Custom vocabulary                                                                                  | Custom spelling                                                                                        |
-| ---------------- | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **What it does** | Listens to how a word _sounds_ and replaces phonetically similar words in the transcript           | Finds exact text strings in the transcript and replaces them with your preferred spelling              |
-| **Mechanism**    | Phoneme-based similarity matching (probabilistic)                                                  | Text-based find-and-replace (deterministic)                                                            |
-| **Best for**     | Words that are consistently mis-transcribed: unusual proper nouns, new product names, niche jargon | Words that are recognizable but misspelled, e.g. "Gaurish" → "Gorish", "data-science" → "Data Science" |
-| **Risk**         | Can produce false positives. Unrelated words that happen to sound similar may get replaced         | No false positives, but it won't help if the word isn't recognized at all                              |
-| **Tuning**       | Adjust `intensity` and `default_intensity` to control aggressiveness                               | None needed. It either matches the text or it doesn't                                                  |
-
-**Rule of thumb:** start with a transcription run _without_ any custom vocabulary. Look at what the output actually says. If the word appears but is just misspelled, custom spelling is the simpler and safer fix. If the word is completely garbled, that's when custom vocabulary is the right tool.
-
-<Tip>
-  If you've been using [custom
-  vocabulary](/chapters/audio-intelligence/custom-vocabulary) and keep running
-  into false positives for certain terms, try moving those terms to [custom
-  spelling](/chapters/audio-intelligence/custom-spelling) instead. As long as
-  the transcription produces something close enough for you to list as a
-  variant, custom spelling will handle the rest, deterministically and without
-  side effects. This is a common and recommended migration path.
-</Tip>

--- a/snippets/custom-vocabulary-vs-spelling.mdx
+++ b/snippets/custom-vocabulary-vs-spelling.mdx
@@ -1,6 +1,6 @@
-**[Custom spelling](/chapters/audio-intelligence/custom-spelling)** fixes the transcription when the model always outputs a close textual match (e.g. **"data-science"** → **"Data Science"**). It applies **literal matching** on strings you list. Make sure to add every possible close words variants.
+Use **[Custom spelling](/chapters/audio-intelligence/custom-spelling)** when the model outputs a recognizable but wrong form. It applies **literal string matching** on variants you list (e.g. **"data-science"** → **"Data Science"**). **List every close variant** the model might output.
 
-**[Custom vocabulary](/chapters/audio-intelligence/custom-vocabulary)** fixes garbled or sound-alike output (e.g. **"le vin"** / **"levine"** → **"Levain"**). It applies **phonemes matching** on strings you list. Entries must cover to potential different spellings of the words.
+Use **[Custom vocabulary](/chapters/audio-intelligence/custom-vocabulary)** when the model outputs garbled or sound-alike text. It applies **phoneme-based matching** on entries you define (e.g. **"le vin"** / **"levine"** → **"Levain"**). **Add pronunciations** for each spelling the model might produce.
 
 | | Custom spelling | Custom vocabulary |
 | --- | --- | --- |

--- a/snippets/custom-vocabulary-vs-spelling.mdx
+++ b/snippets/custom-vocabulary-vs-spelling.mdx
@@ -8,3 +8,4 @@ Use **[Custom vocabulary](/chapters/audio-intelligence/custom-vocabulary)** when
 | **Best for** | Wrong spelling, punctuation, formatting | Phonetically similar mis-transcriptions |
 | **You provide** | All the words that the model outputs wrongly | `value`, `pronunciations`, `intensity` |
 
+**Rule of thumb:** start with a transcription run _without_ any custom vocabulary. Look at what the output actually says. If the word appears but is just misspelled, custom spelling is the simpler and safer fix. If the word is completely garbled, that's when custom vocabulary is the right tool.

--- a/snippets/recommended-params/custom-vocabulary.mdx
+++ b/snippets/recommended-params/custom-vocabulary.mdx
@@ -3,15 +3,9 @@
 **Best practices:**
 
 - **Always provide both** the `custom_vocabulary` flag and a `custom_vocabulary_config`.
-- **Add pronunciations** for words that can be said in different ways (accents, foreign speakers). This is more reliable than raising `intensity`.
+- **Add pronunciations** to provide all the close spelling variants. You can check and Automatic Phonemic Transcriber (IPA) that all the different spellings are covered.
 - **Keep `intensity` moderate** (0.4-0.6). High values increase false positives where unrelated words get replaced.
 - **Set `language`** on individual vocabulary entries when your audio is multilingual and a term is pronounced differently depending on the language.
-
-<Tip>
-  For simple terms that are already close to their phonetic spelling (e.g. brand
-  names), you can pass them as plain strings instead of objects — Gladia will
-  use the default intensity.
-</Tip>
 
 <CodeGroup>
 ```json Pre-recorded
@@ -23,7 +17,7 @@
       "Kubernetes",
       {
         "value": "Gladia",
-        "pronunciations": ["Gladya", "Gladiah"],
+        "pronunciations": ["Glad", "Gladio"],
         "intensity": 0.5
       },
       {
@@ -45,8 +39,9 @@
         "Kubernetes",
         {
           "value": "Gladia",
-          "pronunciations": ["Gladya", "Gladiah"],
-          "intensity": 0.5
+        "value": "Gladia",
+        "pronunciations": ["Glad", "Gladio"],          
+        "intensity": 0.5
         },
         {
           "value": "PostgreSQL",

--- a/snippets/recommended-params/custom-vocabulary.mdx
+++ b/snippets/recommended-params/custom-vocabulary.mdx
@@ -3,7 +3,7 @@
 **Best practices:**
 
 - **Always provide both** the `custom_vocabulary` flag and a `custom_vocabulary_config`.
-- **Add pronunciations** to provide all the close spelling variants. You can check and Automatic Phonemic Transcriber (IPA) that all the different spellings are covered.
+- **Add pronunciations** to provide all the close spelling variants. You can use Automatic Phonemic Transcriber (IPA) in order to check if all the different spellings are covered.
 - **Keep `intensity` moderate** (0.4-0.6). High values increase false positives where unrelated words get replaced.
 - **Set `language`** on individual vocabulary entries when your audio is multilingual and a term is pronounced differently depending on the language.
 
@@ -38,7 +38,6 @@
       "vocabulary": [
         "Kubernetes",
         {
-          "value": "Gladia",
         "value": "Gladia",
         "pronunciations": ["Glad", "Gladio"],          
         "intensity": 0.5


### PR DESCRIPTION
Clarifies and shortens the custom spelling and custom vocabulary docs so the choice between them is obvious:

Custom spelling — literal string replacement after transcription (wrong spelling, punctuation).
Custom vocabulary — phoneme-based replacement when output is garbled or sound-alike.
Both chapter pages now share the same structure (intro → how it works → when to use the other → examples → parameters → tuning → workflow). The comparison snippet is a short table instead of a long one. Recommended-params examples and pronunciation guidance are updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked custom spelling guidance with clearer intro, "How it works", parameter reference, tuning tips, and a recommended workflow.
  * Clarified custom vocabulary as a phoneme-based post-processing step; restructured parameter fields (value/pronunciations/intensity/default intensity) and added tuning guidance.
  * Simplified the comparison between custom spelling and custom vocabulary with updated examples and best-practice recommendations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gladiaio/docs/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->