### PR TITLE
[GLA-3025] docs: remove YouTube mentions from supported formats

### DIFF
--- a/chapters/limits-and-specifications/supported-formats.mdx
+++ b/chapters/limits-and-specifications/supported-formats.mdx
@@ -17,7 +17,6 @@ Those limits will be gradually lifted to ensure the full stability and performan
 
 - **Audio length (pre-recorded)**: The maximum length of audio that can be transcribed in a single request is currently
 135 minutes. Attempts to transcribe longer audio files will result in an error.
-Direct YouTube links are limited to 120 minutes instead of 135 minutes.
 
 <Tip> 
   We support up to 4h15 audio length for enterprise plans.
@@ -74,7 +73,6 @@ Following these best practices will help you avoid issues due to limitations and
 
 | Platform       | Audio/Video Support | Stage        |
 |----------------|---------------------|--------------|
-| YouTube        | Video               | Released     |
 | TikTok         | Video               | Released     |
 | Instagram      | Video               | Released     |
 | Facebook       | Video               | Released     |

--- a/chapters/limits-and-specifications/supported-formats.mdx
+++ b/chapters/limits-and-specifications/supported-formats.mdx
@@ -71,8 +71,6 @@ Following these best practices will help you avoid issues due to limitations and
 
 ## Supported online video services
 
-{/* YouTube support removed — see Linear GLA-3025: https://linear.app/gladia/issue/GLA-3025 */}
-
 | Platform       | Audio/Video Support | Stage        |
 |----------------|---------------------|--------------|
 | TikTok         | Video               | Released     |

--- a/chapters/limits-and-specifications/supported-formats.mdx
+++ b/chapters/limits-and-specifications/supported-formats.mdx
@@ -71,6 +71,8 @@ Following these best practices will help you avoid issues due to limitations and
 
 ## Supported online video services
 
+{/* YouTube support removed — see Linear GLA-3025: https://linear.app/gladia/issue/GLA-3025 */}
+
 | Platform       | Audio/Video Support | Stage        |
 |----------------|---------------------|--------------|
 | TikTok         | Video               | Released     |


### PR DESCRIPTION
## Summary
- Remove the 120-minute YouTube link limitation note
- Remove the YouTube row from the supported online video services table

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed YouTube from the list of supported online video services for media transcription.
  * Removed the special-case limitation note for YouTube links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->