### PR TITLE
docs(samples): fix javascript deadlink

### DIFF
--- a/snippets/samples.mdx
+++ b/snippets/samples.mdx
@@ -19,7 +19,7 @@ You can find complete code samples in our Github repository:
   <Card
     title="Browser"
     icon="browser"
-    href="https://github.com/gladiaio/gladia-samples/tree/main/javascript-browser"
+    href="https://github.com/gladiaio/gladia-samples/tree/main/javascript"
   >
   {}
   </Card>


### PR DESCRIPTION
A small fix of the URL for samples of live-transcription

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Browser card link to point to the correct GitHub repository page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->