### PR TITLE
fix(n8n): update n8n integration instructions to reflect new package name

### DIFF
--- a/chapters/integrations/n8n.mdx
+++ b/chapters/integrations/n8n.mdx
@@ -8,7 +8,7 @@ description: "How to use Gladia with n8n"
 n8n is an open-source workflow automation platform that lets you connect apps, APIs, and services through a visual node-based editor. The official Gladia community node for n8n makes it easy to add speech-to-text transcription to any workflow — supporting audio from a URL or directly from binary data piped between nodes.
 
 <Tip>
-  Install the Gladia node directly from your n8n instance: go to **Settings → Community Nodes**, search for `@gladiaio/n8n-nodes`, and click Install.
+  Install the Gladia node directly from your n8n instance: go to **Settings → Community Nodes**, search for `@gladiaio/n8n-nodes-gladia`, and click Install.
   Community node installation requires a self-hosted n8n instance.
 </Tip>
 
@@ -31,7 +31,7 @@ n8n is an open-source workflow automation platform that lets you connect apps, A
 Install the node from the n8n UI or via npm:
 
 ```bash
-npm install @gladiaio/n8n-nodes
+npm install @gladiaio/n8n-nodes-gladia
 ```
 
 Then restart your n8n instance.
@@ -71,9 +71,9 @@ The Gladia n8n node exposes the full Gladia feature set:
     Get your API key on the Gladia dashboard
   </Card>
   <Card
-    title="@gladiaio/n8n-nodes on npm"
+    title="@gladiaio/n8n-nodes-gladia on npm"
     icon="npm"
-    href="https://www.npmjs.com/package/@gladiaio/n8n-nodes"
+    href="https://www.npmjs.com/package/@gladiaio/n8n-nodes-gladia"
   >
     View the package and release notes
   </Card>


### PR DESCRIPTION
Updated n8n node package url following to renaming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the n8n integration guide with the current community node name and npm package references.
  * Corrected installation instructions and package links for the Gladia n8n integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->